### PR TITLE
markupsafe limitation removed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -133,12 +133,7 @@ install_requires =
     lazy-object-proxy
     lockfile>=0.12.2
     markdown>=3.0
-    # Markupsafe 2.1.0 breaks with error: import name 'soft_unicode' from 'markupsafe'.
-    # This should be removed when either this issue is closed:
-    # https://github.com/pallets/markupsafe/issues/284
-    # or when we will be able to upgrade JINJA to newer version (currently limited due to Flask and
-    # Flask Application Builder)
-    markupsafe>=1.1.1,<2.1.0
+    markupsafe>=1.1.1
     marshmallow-oneofschema>=2.0.1
     packaging>=14.0
     pendulum>=2.0


### PR DESCRIPTION
@potiuk pinned down the version due to limitations explained in this commit:
https://github.com/apache/airflow/commit/366c66b8f6eddc0d22028ef494c62bb757bd8b8b
The limitations have been lifted since issue https://github.com/pallets/markupsafe/issues/284 was closed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
